### PR TITLE
Add missing standard headers.

### DIFF
--- a/farmhash.h
+++ b/farmhash.h
@@ -18,8 +18,10 @@
 #ifndef HASHING_DEMO_FARMHASH_H
 #define HASHING_DEMO_FARMHASH_H
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <utility>
 
 #include "std_impl.h"

--- a/std_impl.h
+++ b/std_impl.h
@@ -21,6 +21,7 @@
 
 #include <cstddef>
 #include <forward_list>
+#include <memory>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Without these the compile fails with libstdc++. However, the compile fails due to bugs with libstdc++ as well, so this is somewhat of a pedantic fix.
